### PR TITLE
Add date and dateTime data types

### DIFF
--- a/app/no/samordnaopptak/SwaggerUtil.scala
+++ b/app/no/samordnaopptak/SwaggerUtil.scala
@@ -9,7 +9,7 @@ import no.samordnaopptak.json._
 
 object SwaggerUtil{
 
-  val atomTypes = Set("etc.", "String", "Long", "Boolean", "Integer", "Int", "Any", "Double", "Float")
+  val atomTypes = Set("etc.", "String", "Long", "Boolean", "Integer", "Int", "Any", "Double", "Float", "Date", "DateTime")
 
 
   // https://github.com/swagger-api/swagger-core/wiki/Datatypes
@@ -24,6 +24,8 @@ object SwaggerUtil{
       case "Any" => ("any","")
       case "Double" => ("number","double")
       case "Float" => ("number","float")
+      case "Date" => ("string", "date")
+      case "DateTime" => ("string", "date-time")
     }
     if (format=="")
       J.obj(

--- a/test/SwaggerUtilSpec.scala
+++ b/test/SwaggerUtilSpec.scala
@@ -37,6 +37,8 @@ object SwaggerTestData{
       extra: Extra(optional)
       type: Enum(man, woman, dog) String(optional)
       age: Enum(2,65,9) String
+      birthday: Date
+      created: DateTime
 
     Extra: !
       extrastring: String <- Extra type
@@ -282,7 +284,7 @@ object SwaggerTestData{
   "definitions": {
         "User": {
             "id" : "User",
-            "required" : ["id", "names", "age", "${___ignoreOrder.value}"],
+            "required" : ["id", "names", "age", "birthday", "created", "${___ignoreOrder.value}"],
             "properties": {
                 "id": {
                     "type": "integer",
@@ -312,6 +314,14 @@ object SwaggerTestData{
                     "enum": [
                        "2","65","9"
                     ]
+                },
+                "birthday": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
                 }
             }
         },


### PR DESCRIPTION
The Swagger 2.0 spec defines some default primitive data types, such as
date and dateTime which map to a String in ISO 8601 format.

See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types